### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for Ansible automation. This server allows AI assistants to interact with Ansible, execute playbooks, manage inventory, and perform other Ansible operations directly.
 
+<a href="https://glama.ai/mcp/servers/@tarnover/mcp-ansible">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tarnover/mcp-ansible/badge" alt="Ansible Server MCP server" />
+</a>
+
 ## Features
 
 - **Run Ansible Playbooks**: Execute Ansible playbooks with support for parameters like inventory, extra vars, tags, and limits


### PR DESCRIPTION
This PR adds a badge for the [Ansible MCP Server](https://glama.ai/mcp/servers/@tarnover/mcp-ansible) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@tarnover/mcp-ansible">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tarnover/mcp-ansible/badge" alt="Ansible Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.