### PR TITLE
Fix ELB tool schema validation error for array parameters

### DIFF
--- a/src/sysoperator/common/types.ts
+++ b/src/sysoperator/common/types.ts
@@ -29,6 +29,9 @@ export type Route53Action = z.infer<typeof Route53ActionEnum>;
 export const ELBActionEnum = z.enum(['list', 'create', 'delete']);
 export type ELBAction = z.infer<typeof ELBActionEnum>;
 
+const ELBListenerSchema = z.object({}).passthrough();
+const ELBTargetGroupSchema = z.object({}).passthrough();
+
 export const LambdaActionEnum = z.enum(['list', 'create', 'update', 'delete', 'invoke']);
 export type LambdaAction = z.infer<typeof LambdaActionEnum>;
 
@@ -159,10 +162,10 @@ export const ELBSchema = z.object({
   scheme: z.string().optional(),
   subnets: z.array(z.string()).optional(),
   securityGroups: z.array(z.string()).optional(),
-  listeners: z.array(z.any()).optional(), // Consider defining a more specific listener schema
+  listeners: z.array(ELBListenerSchema).optional(),
   healthCheck: z.any().optional(), // Consider defining a more specific health check schema
   tags: z.record(z.string()).optional(),
-  targetGroups: z.array(z.any()).optional() // Added based on usage in aws.ts. Consider a specific schema.
+  targetGroups: z.array(ELBTargetGroupSchema).optional()
 });
 
 export type ELBOptions = z.infer<typeof ELBSchema>;


### PR DESCRIPTION
### Motivation
- MCP client validation rejected the ELB tool because array parameter schemas were generated without `items`, causing the error `tool parameters array type must have items`.
- The root cause was use of `z.array(z.any())` which produces an array type with no concrete `items` in the JSON Schema output.

### Description
- Introduced permissive object schemas `ELBListenerSchema` and `ELBTargetGroupSchema` defined as `z.object({}).passthrough()` to represent listener and target-group entries.
- Replaced `listeners: z.array(z.any()).optional()` with `listeners: z.array(ELBListenerSchema).optional()` and `targetGroups: z.array(z.any()).optional()` with `targetGroups: z.array(ELBTargetGroupSchema).optional()` in `src/sysoperator/common/types.ts` so generated JSON Schema includes `items` for these arrays.
- Kept the shapes permissive (still accept arbitrary object keys) while producing standards-compliant JSON Schema for MCP tooling.

### Testing
- Ran `npm run build` (which runs `tsc`) and the build succeeded without errors.
- Ran a quick schema verification using `node` + `zod-to-json-schema` to inspect `ELBSchema` and confirmed the generated JSON Schema includes `items` for both `listeners` and `targetGroups`, and that the arrays are now represented as `type: "array"` with an `items` object.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954565c5cc83309567a92f13922232)